### PR TITLE
fix git check-ref-format call

### DIFF
--- a/post-receive/dynamic-environments
+++ b/post-receive/dynamic-environments
@@ -41,7 +41,7 @@ $stdin.each_line do |line|
 
   # Check if the branch name is valid.
   branchname = refname.sub(%r{^refs/heads/(.*$)}) { $1 }
-  if ! system('git check-ref-format --branch "#{branchname}"') || $?.exitstatus > 0
+  unless system("git check-ref-format --branch '#{branchname}' >& /dev/null")
     puts %Q{Branchname "#{branchname}" is not valid.} 
     next
   end


### PR DESCRIPTION
fix quotes in git check-ref-format call, otherwise it's useless.

What's the deal with the following construct? isn't it the same as if !system ?? If not I can put it back.

```
if !system("...") || $?.existatus > 0
```
