### PR TITLE
fix bashism in git check-ref-format call

### DIFF
--- a/post-receive/dynamic-environments
+++ b/post-receive/dynamic-environments
@@ -41,7 +41,7 @@ $stdin.each_line do |line|
 
   # Check if the branch name is valid.
   branchname = refname.sub(%r{^refs/heads/(.*$)}) { $1 }
-  unless system("git check-ref-format --branch '#{branchname}' >& /dev/null")
+  unless system("git check-ref-format --branch '#{branchname}' > /dev/null 2>&1")
     puts %Q{Branchname "#{branchname}" is not valid.} 
     next
   end


### PR DESCRIPTION
'system' spawns a default shell, and on many systems (e.g. Debian
starting with 6.0 / Squeezy) the default shell isn't /bin/bash but
/bin/dash instead. So let's only use POSIX features and drop the
bash-specific '>&' shortcut.
